### PR TITLE
Ignore quetzals with unbuilt landing sites

### DIFF
--- a/src/main/java/shortestpath/Transport.java
+++ b/src/main/java/shortestpath/Transport.java
@@ -112,6 +112,9 @@ public class Transport {
 
         this.varbits.addAll(origin.varbits);
         this.varbits.addAll(destination.varbits);
+
+        this.varPlayers.addAll(origin.varPlayers);
+        this.varPlayers.addAll(destination.varPlayers);
     }
 
     Transport(Map<String, String> fieldMap, TransportType transportType) {

--- a/src/main/java/shortestpath/Transport.java
+++ b/src/main/java/shortestpath/Transport.java
@@ -11,6 +11,8 @@ import lombok.Getter;
 import net.runelite.api.Quest;
 import net.runelite.api.Skill;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.gameval.VarPlayerID;
+import net.runelite.api.gameval.VarbitID;
 
 /**
  * This class represents a travel point between two WorldPoints.
@@ -245,7 +247,12 @@ public class Transport {
                     for (TransportVarCheck check : TransportVarCheck.values()) {
                         varbitParts = varbitRequirement.split(check.getCode());
                         if (varbitParts.length == 2) {
-                            int varbitId = Integer.parseInt(varbitParts[0]);
+                            int varbitId;
+                            try {
+                                varbitId = Integer.parseInt(varbitParts[0]);
+                            } catch (NumberFormatException ignored) {
+                                varbitId = VarbitID.class.getDeclaredField(varbitParts[0].toUpperCase()).getInt(null);
+                            }
                             int varbitValue = Integer.parseInt(varbitParts[1]);
                             varbits.add(new TransportVarbit(varbitId, varbitValue, check));
                             break;
@@ -253,7 +260,7 @@ public class Transport {
                     }
                     assert varbitParts.length == 2 : "Invalid varbit id and value: '" + varbitRequirement + "'";
                 }
-            } catch (NumberFormatException e) {
+            } catch (NumberFormatException | NoSuchFieldException | IllegalAccessException e) {
                 log.error("Invalid varbit id and value: " + value);
             }
         }
@@ -268,7 +275,12 @@ public class Transport {
                     for (TransportVarCheck check : TransportVarCheck.values()) {
                         varPlayerParts = varPlayerRequirement.split(check.getCode());
                         if (varPlayerParts.length == 2) {
-                            int varPlayerId = Integer.parseInt(varPlayerParts[0]);
+                            int varPlayerId;
+                            try {
+                                varPlayerId = Integer.parseInt(varPlayerParts[0]);
+                            } catch (NumberFormatException ignored) {
+                                varPlayerId = VarPlayerID.class.getDeclaredField(varPlayerParts[0].toUpperCase()).getInt(null);
+                            }
                             int varPlayerValue = Integer.parseInt(varPlayerParts[1]);
                             varPlayers.add(new TransportVarPlayer(varPlayerId, varPlayerValue, check));
                             break;
@@ -276,7 +288,7 @@ public class Transport {
                     }
                     assert varPlayerParts.length == 2 : "Invalid VarPlayer id and value: '" + varPlayerRequirement + "'";
                 }
-            } catch (NumberFormatException e) {
+            } catch (NumberFormatException | NoSuchFieldException | IllegalAccessException e) {
                 log.error("Invalid VarPlayer id and value: " + value);
             }
         }

--- a/src/main/resources/transports/quetzals.tsv
+++ b/src/main/resources/transports/quetzals.tsv
@@ -1,25 +1,25 @@
-# Origin	Destination	Quests	Duration	Display info
+# Origin	Destination	Quests	Duration	Display info	VarPlayers
 3280 3412 0	1700 3141 0	Children of the Sun	6	Civitas illa Fortis
 1703 3140 0	3280 3412 0	Children of the Sun	6	Varrock
-1389 2901 0		Twilight's Promise	6	
-1697 3140 0		Twilight's Promise	6	
-1585 3053 0		Twilight's Promise	6	
-1512 3222 0		Twilight's Promise	6	
-1548 2995 0		Twilight's Promise	6	
-1437 3171 0		Twilight's Promise	6	
-1779 3111 0		Twilight's Promise	6	
-1700 3037 0		Twilight's Promise	6	
-1670 2933 0		Twilight's Promise	6	
-1446 3108 0		Twilight's Promise	6	
-1613 3300 0		Twilight's Promise	6	
+1389 2901 0		Twilight's Promise	6
+1697 3140 0		Twilight's Promise	6
+1585 3053 0		Twilight's Promise	6
+1512 3222 0		Twilight's Promise	6
+1548 2995 0		Twilight's Promise	6
+1437 3171 0		Twilight's Promise	6
+1779 3111 0		Twilight's Promise	6		quetzals_unlocked&256
+1700 3037 0		Twilight's Promise	6		quetzals_unlocked&128
+1670 2933 0		Twilight's Promise	6		quetzals_unlocked&64
+1446 3108 0		Twilight's Promise	6		quetzals_unlocked&32
+1613 3300 0		Twilight's Promise	6		quetzals_unlocked&2048
 	1389 2901 0	Twilight's Promise	6	Aldarin
 	1697 3140 0	Twilight's Promise	6	Civitas illa Fortis
 	1585 3053 0	Twilight's Promise	6	Hunter Guild
 	1512 3222 0	Twilight's Promise	6	Quetzacalli Gorge
 	1548 2995 0	Twilight's Promise	6	Sunset Coast
 	1437 3171 0	Twilight's Promise	6	The Teomat
-	1779 3111 0	Twilight's Promise	6	Fortis Colosseum
-	1700 3037 0	Twilight's Promise	6	Outer Fortis
-	1670 2933 0	Twilight's Promise	6	Colossal Wyrm Remains
-	1446 3108 0	Twilight's Promise	6	Cam Torum
-	1613 3300 0	Twilight's Promise	6	Salvager Overlook
+	1779 3111 0	Twilight's Promise	6	Fortis Colosseum	quetzals_unlocked&256
+	1700 3037 0	Twilight's Promise	6	Outer Fortis	quetzals_unlocked&128
+	1670 2933 0	Twilight's Promise	6	Colossal Wyrm Remains	quetzals_unlocked&64
+	1446 3108 0	Twilight's Promise	6	Cam Torum	quetzals_unlocked&32
+	1613 3300 0	Twilight's Promise	6	Salvager Overlook	quetzals_unlocked&2048


### PR DESCRIPTION
This makes Shortest Path significantly more useful in Varlamore if you haven't built all the landing sites yet.

Landing sites don't have a varbit defined, they just use bits on the `quetzals_unlocked` varp. (Their indices can be found by looking at the `quetzal:id` DBTable column -- `quetzal_camtorum` has it set to 5, so the mask is `1 << 5`.)

I made a couple of other tweaks to the `Transport` class here:
- Added support for specifying varps/varbits by name since those are now included in gamevals
- Added varps to the logic for merging requirements - seems like this was overlooked, but it's required for quetzals